### PR TITLE
updated tasty dependency constraint

### DIFF
--- a/OTP.cabal
+++ b/OTP.cabal
@@ -79,7 +79,7 @@ test-suite tests
                     , OTP
                     , time
                     -- dependency constraints not inherited via 'OTP' component
-                    , tasty == 1.1.*
+                    , tasty >= 1.1 && < 1.3
                     , tasty-hunit == 0.10.*
 
   ghc-options:        -Wall


### PR DESCRIPTION
couldn't include it into my app as nixos-18.09 includes a tasty 1.2.* and the cabalfile was hardcoded to 1.1.*
I've checked that tests pass OK with 1.2