### PR TITLE
Update to GHC2021 (GHC 9.6.2), release upper bounds and add Github Haskell CI build workflow

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,43 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: '9.6.2'
+        cabal-version: '3.2'
+
+    - name: Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: cabal build --enable-tests --enable-benchmarks all
+    - name: Run tests
+      run: cabal test all

--- a/OTP.cabal
+++ b/OTP.cabal
@@ -26,7 +26,7 @@ homepage:      https://github.com/hvr/OTP
 bug-reports:   https://github.com/hvr/OTP/issues
 category:      Cryptography
 build-type:    Simple
-tested-with:   GHC=9.6.2, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:   GHC==9.6.2, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 
 extra-source-files:
   CHANGELOG.md
@@ -46,7 +46,7 @@ library
   exposed-modules:    Data.OTP
   other-modules:      HashImpl
 
-  default-language:   Haskell2010
+  default-language:   GHC2021
   other-extensions:   CPP
 
   if flag(pure-sha)
@@ -71,7 +71,7 @@ test-suite tests
   hs-source-dirs:     test
   main-is:            Test.hs
 
-  default-language:   Haskell2010
+  default-language:   GHC2021
   other-extensions:   OverloadedStrings
 
   build-depends:      base

--- a/OTP.cabal
+++ b/OTP.cabal
@@ -26,7 +26,7 @@ homepage:      https://github.com/hvr/OTP
 bug-reports:   https://github.com/hvr/OTP/issues
 category:      Cryptography
 build-type:    Simple
-tested-with:   GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:   GHC=9.6.2, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 
 extra-source-files:
   CHANGELOG.md
@@ -50,17 +50,17 @@ library
   other-extensions:   CPP
 
   if flag(pure-sha)
-    build-depends:    SHA                >= 1.6.4.4    && < 1.7
-                    , bytestring         >= 0.10.0.0   && < 0.11
-                    , base               >= 4.3.0.0    && < 4.12
-                    , time               >= 1.2        && < 1.9
+    build-depends:    SHA                >= 1.6.4.4
+                    , bytestring         >= 0.10.0.0
+                    , base               >= 4.3.0.0
+                    , time               >= 1.2   
   else
-    build-depends:    cryptohash-sha1    >= 0.11.100.1 && < 0.12
-                    , cryptohash-sha256  >= 0.11.100.1 && < 0.12
-                    , cryptohash-sha512  >= 0.11.100.1 && < 0.12
-                    , bytestring         >= 0.9.2.0    && < 0.11
-                    , base               >= 4.5.0.0    && < 4.12
-                    , time               >= 1.4        && < 1.9
+    build-depends:    cryptohash-sha1    >= 0.11.100.1
+                    , cryptohash-sha256  >= 0.11.100.1
+                    , cryptohash-sha512  >= 0.11.100.1
+                    , bytestring         >= 0.9.2.0    
+                    , base               >= 4.5.0.0    && <5
+                    , time               >= 1.4        
 
   ghc-options:        -Wall
 
@@ -79,7 +79,7 @@ test-suite tests
                     , OTP
                     , time
                     -- dependency constraints not inherited via 'OTP' component
-                    , tasty >= 1.1 && < 1.3
+                    , tasty >= 1.1
                     , tasty-hunit == 0.10.*
 
   ghc-options:        -Wall

--- a/OTP.cabal
+++ b/OTP.cabal
@@ -26,7 +26,7 @@ homepage:      https://github.com/hvr/OTP
 bug-reports:   https://github.com/hvr/OTP/issues
 category:      Cryptography
 build-type:    Simple
-tested-with:   GHC=9.6.2, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
+tested-with:   GHC==9.6.2, GHC==8.4.3, GHC==8.2.2, GHC==8.0.2, GHC==7.10.3, GHC==7.8.4, GHC==7.6.3, GHC==7.4.2
 
 extra-source-files:
   CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `OTP`: HMAC-Based and Time-Based One-Time Passwords (HOTP & TOTP)  [![Hackage](https://img.shields.io/hackage/v/OTP.svg)](https://hackage.haskell.org/package/OTP) [![Build Status](https://travis-ci.org/haskell-hvr/OTP.svg)](https://travis-ci.org/haskell-hvr/OTP)
+# `OTP`: HMAC-Based and Time-Based One-Time Passwords (HOTP & TOTP)  [![Hackage](https://img.shields.io/hackage/v/OTP.svg)](https://hackage.haskell.org/package/OTP) [![Haskell CI](https://github.com/sigrdrifa/OTP/actions/workflows/haskell.yml/badge.svg)](https://github.com/sigrdrifa/OTP/actions/workflows/haskell.yml)
 
 **Please refer to the [package description](https://hackage.haskell.org/package/OTP#description) for an overview of `OTP`.**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `OTP`: HMAC-Based and Time-Based One-Time Passwords (HOTP & TOTP)  [![Hackage](https://img.shields.io/hackage/v/OTP.svg)](https://hackage.haskell.org/package/OTP) [![Haskell CI](https://github.com/sigrdrifa/OTP/actions/workflows/haskell.yml/badge.svg)](https://github.com/sigrdrifa/OTP/actions/workflows/haskell.yml)
+# `OTP`: HMAC-Based and Time-Based One-Time Passwords (HOTP & TOTP)  [![Hackage](https://img.shields.io/hackage/v/OTP.svg)](https://hackage.haskell.org/package/OTP) [![Haskell CI](https://github.com/haskell-hvr/OTP/actions/workflows/haskell.yml/badge.svg)](https://github.com/haskell-hvr/OTP/actions/workflows/haskell.yml)
 
 **Please refer to the [package description](https://hackage.haskell.org/package/OTP#description) for an overview of `OTP`.**
 


### PR DESCRIPTION
This PR removes the upper bounds and builds the package with GHC2021 (tested with GHC 9.6.2) as well as adding a Github Haskell CI workflow.

The build was tested with GHC 9.6.2 with all tests passing and the functionality in tact.